### PR TITLE
Rename Text to DOMString and introduce a new Paragraph-like Text element

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Usage
 
-First add Slipstream to your package dependencies:
+Add Slipstream to your package dependencies:
 
 ```swift
 dependencies: [

--- a/Sources/Slipstream/Documentation.docc/Architecture/SlipstreamforSwiftUIDevelopers.md
+++ b/Sources/Slipstream/Documentation.docc/Architecture/SlipstreamforSwiftUIDevelopers.md
@@ -1,0 +1,67 @@
+# Slipstream for SwiftUI developers
+
+An exhaustive comparison of Slipstream features to equivalent SwiftUI features.
+
+## The basics
+
+SwiftUI's most primitive type is [View](https://developer.apple.com/documentation/swiftui/view).
+
+Slipstream's most primitive type is also ``View``, but a Slipstream-specific definition of the type.
+
+If you try to import both frameworks in a single swift file, you will get naming conflicts:
+
+```swift
+import Slipstream
+import SwiftUI
+
+struct HelloWorld: View {  // 'View' is ambiguous for type lookup in this context
+  var body: some View {
+    Text("Hello, world!")
+  }
+}
+```
+
+This is working as intended: you're not really meant to use SwiftUI and Slipstream in the same
+code. The trade-off here is that it makes working with Slipstream feel much more natural if you're
+already familiar with SwiftUI.
+
+## Stacks
+
+SwiftUI's [HStack](https://developer.apple.com/documentation/swiftui/hstack) and
+[VStack](https://developer.apple.com/documentation/swiftui/vstack) define essential primitives for
+creating structured layouts, and equivalent types are provided in Slipstream.
+
+VStack in SwiftUI:
+
+```
+var body: some View {
+  VStack(
+    alignment: .leading,
+    spacing: 10
+  ) {
+    ForEach(
+      1...10,
+      id: \.self
+    ) {
+      Text("Item \($0)")
+    }
+  }
+}
+```
+
+VStack in Slipstream:
+
+```
+var body: some View {
+  VStack(
+    alignment: .leading,
+    spacing: 10
+  ) {
+    for index in 1...10, {
+      Text("Item \($0)")
+    }
+  }
+}
+```
+
+

--- a/Sources/Slipstream/Documentation.docc/Slipstream.md
+++ b/Sources/Slipstream/Documentation.docc/Slipstream.md
@@ -54,6 +54,7 @@ print(try renderHTML(HelloWorld()))
 
 - <doc:HowSlipstreamWorks>
 - <doc:HowEnvironmentWorks>
+- <doc:SlipstreamforSwiftUIDevelopers>
 
 ### Data and storage
 

--- a/Sources/Slipstream/Documentation.docc/theme-settings.json
+++ b/Sources/Slipstream/Documentation.docc/theme-settings.json
@@ -3,7 +3,7 @@
     "color": {
       "documentation-intro-fill": {
         "dark": "linear-gradient(180deg, rgba(50,4,32,1) 25%, rgba(229,77,123,0.8) 100%)",
-        "light": "linear-gradient(180deg, rgba(229,77,123,0.1) 0%, rgba(229,77,123,0.3) 100%)"
+        "light": "linear-gradient(180deg, rgba(229,77,123,0.1) 0%, rgba(229,77,123,0.0) 100%)"
       }
     }
   }

--- a/Sources/Slipstream/Fundamentals/DOMString.swift
+++ b/Sources/Slipstream/Fundamentals/DOMString.swift
@@ -4,7 +4,7 @@ import SwiftSoup
 ///
 /// A text view adds a string to your HTML document.
 @available(iOS 17.0, macOS 14.0, *)
-public struct Text: View {
+public struct DOMString: View {
   private let content: any StringProtocol
 
   /// Creates a text view that displays a stored string without localization.
@@ -14,7 +14,7 @@ public struct Text: View {
   ///
   /// ```swift
   /// // Display the contents of `someString` without localization.
-  /// Text(someString)
+  /// DOMString(someString)
   /// ```
   ///
   /// The provided string will be rendered as-is in your HTML document, meaning

--- a/Sources/Slipstream/Fundamentals/ViewBuilder/ViewBuilder.swift
+++ b/Sources/Slipstream/Fundamentals/ViewBuilder/ViewBuilder.swift
@@ -12,7 +12,7 @@ public struct ViewBuilder {
   ///
   /// ```swift
   /// var body: some View {
-  ///   Text("Hello")
+  ///   DOMString("Hello")
   /// }
   /// ```
   public static func buildBlock<Content>(_ content: Content) -> Content where Content: View {
@@ -25,8 +25,8 @@ public struct ViewBuilder {
   ///
   /// ```swift
   /// var body: some View {
-  ///   Text("Hello, ")
-  ///   Text("world!")
+  ///   DOMString("Hello, ")
+  ///   DOMString("world!")
   /// }
   /// ```
   public static func buildBlock<each Content>(_ content: repeat each Content) -> TupleView<(repeat each Content)>
@@ -41,7 +41,7 @@ public struct ViewBuilder {
   /// ```swift
   /// var body: some View {
   ///   if true {
-  ///     Text("true")
+  ///     DOMString("true")
   ///   }
   /// }
   /// ```
@@ -61,9 +61,9 @@ public struct ViewBuilder {
   /// ```swift
   /// var body: some View {
   ///   if true {
-  ///     Text("true")
+  ///     DOMString("true")
   ///   } else {
-  ///     Text("false")
+  ///     DOMString("false")
   ///   }
   /// }
   /// ```
@@ -79,9 +79,9 @@ public struct ViewBuilder {
   /// ```swift
   /// var body: some View {
   ///   if false {
-  ///     Text("true")
+  ///     DOMString("true")
   ///   } else {
-  ///     Text("false")
+  ///     DOMString("false")
   ///   }
   /// }
   /// ```
@@ -97,7 +97,7 @@ public struct ViewBuilder {
   /// ```swift
   /// var body: some View {
   ///    for i in 1...3 {
-  ///      Text("\(i)")
+  ///      DOMString("\(i)")
   ///    }
   /// }
   /// ```

--- a/Sources/Slipstream/TailwindCSS/Layout/ResponsiveStack.swift
+++ b/Sources/Slipstream/TailwindCSS/Layout/ResponsiveStack.swift
@@ -6,10 +6,10 @@
 ///     Body {
 ///       ResponsiveStack {
 ///         Div {
-///           Text("Hello,")
+///           DOMString("Hello,")
 ///         }
 ///         Div {
-///           Text("world!")
+///           DOMString("world!")
 ///         }
 ///       }
 ///     }

--- a/Sources/Slipstream/TailwindCSS/Layout/VStack.swift
+++ b/Sources/Slipstream/TailwindCSS/Layout/VStack.swift
@@ -1,3 +1,20 @@
+/// Constants that provide SwiftUI-like constants for specifying VStack item alignment.
+@available(iOS 17.0, macOS 14.0, *)
+public enum VStackAlignment {
+  /// Equivalent to ``AlignItems/start``.
+  case leading
+
+  /// Equivalent to ``AlignItems/end``.
+  case trailing
+
+  var alignItemsEquivalent: AlignItems {
+    switch self {
+    case .leading:  return .start
+    case .trailing: return .end
+    }
+  }
+}
+
 /// A flex view that positions its views vertically.
 ///
 /// ```swift
@@ -20,9 +37,10 @@
 /// ## See Also
 ///
 /// - ``AlignItems``
+/// - ``VStackAlignment``
 @available(iOS 17.0, macOS 14.0, *)
 public struct VStack<Content: View>: View {
-  /// Creates an HStack view.
+  /// Creates a VStack.
   ///
   /// - Parameters:
   ///   - alignment: Determines how items within the stack are positioned along the x axis.
@@ -40,6 +58,28 @@ public struct VStack<Content: View>: View {
     self.spacing = spacing
     self.reversed = reversed
     self.content = content
+  }
+
+  /// Creates a VStack using SwiftUI-like alignment terminology.
+  ///
+  /// - Parameters:
+  ///   - alignment: Determines how items within the stack are positioned along the x axis.
+  ///   - spacing: If provided, the amount of spacing to add between child views. The value is
+  ///   expressed in points, and mapped to the closest Tailwind CSS spacing class.
+  ///   - reversed: If true, the contents will be arranged vertically from bottom to top.
+  ///   - content: The content to display with this view.
+  public init(
+    alignment: VStackAlignment,
+    spacing: Double? = nil,
+    reversed: Bool = false,
+    @ViewBuilder content: @escaping () -> Content
+  ) {
+    self.init(
+      alignment: alignment.alignItemsEquivalent,
+      spacing: spacing,
+      reversed: reversed,
+      content: content
+    )
   }
 
   @_documentation(visibility: private)

--- a/Sources/Slipstream/W3C/Elements/GroupingContent/Blockquote.swift
+++ b/Sources/Slipstream/W3C/Elements/GroupingContent/Blockquote.swift
@@ -5,7 +5,7 @@
 ///   var body: some View {
 ///     Body {
 ///       Blockquote {
-///         Text("Hello, world!")
+///         DOMString("Hello, world!")
 ///       }
 ///     }
 ///   }
@@ -27,9 +27,9 @@ public struct Blockquote<Content>: W3CElement where Content: View {
   }
 
   /// Creates a blockquote with some static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/GroupingContent/Div.swift
+++ b/Sources/Slipstream/W3C/Elements/GroupingContent/Div.swift
@@ -8,7 +8,7 @@
 ///   var body: some View {
 ///     Body {
 ///       Div {
-///         Text("Hello, world!")
+///         DOMString("Hello, world!")
 ///       }
 ///     }
 ///   }

--- a/Sources/Slipstream/W3C/Elements/GroupingContent/Paragraph.swift
+++ b/Sources/Slipstream/W3C/Elements/GroupingContent/Paragraph.swift
@@ -25,9 +25,9 @@ public struct Paragraph<Content>: W3CElement where Content: View {
   }
 
   /// Creates a paragraph with some static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/GroupingContent/Preformatted.swift
+++ b/Sources/Slipstream/W3C/Elements/GroupingContent/Preformatted.swift
@@ -27,9 +27,9 @@ public struct Preformatted<Content>: W3CElement where Content: View {
   }
 
   /// Creates a preformatted view with some static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/GroupingContent/Text.swift
+++ b/Sources/Slipstream/W3C/Elements/GroupingContent/Text.swift
@@ -1,33 +1,39 @@
-/// A view that represents a heading for a section.
+/// A view that is equivalent to a ``Paragraph`` and roughly mimics
+/// the behavior of SwiftUI's equivalent type.
 ///
 /// ```swift
 /// struct MySiteContent: View {
 ///   var body: some View {
 ///     Body {
-///       H3("Hello, world!")
+///       Text("Hello, world!")
 ///     }
 ///   }
 /// }
 /// ```
 ///
-/// - SeeAlso: W3C [`h1-h6`](https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements) specification.
+/// ## See Also
+///
+/// - ``Paragraph``
 @available(iOS 17.0, macOS 14.0, *)
-public struct H3<Content>: W3CElement where Content: View {
-  @_documentation(visibility: private)
-  public let tagName: String = "h3"
+public struct Text<Content>: View where Content: View {
 
   @_documentation(visibility: private)
   @ViewBuilder public let content: () -> Content
 
-  /// Creates an H3 view.
+  /// Creates a text view.
   public init(@ViewBuilder content: @escaping () -> Content) {
     self.content = content
   }
 
-  /// Creates an H3 view with some static text.
+  /// Creates a text view with static text.
   public init(_ text: String) where Content == DOMString {
     self.content = {
       DOMString(text)
     }
+  }
+
+  @_documentation(visibility: private)
+  public var body: some View {
+    Paragraph(content: content)
   }
 }

--- a/Sources/Slipstream/W3C/Elements/Sections/H1.swift
+++ b/Sources/Slipstream/W3C/Elements/Sections/H1.swift
@@ -25,9 +25,9 @@ public struct H1<Content>: W3CElement where Content: View {
   }
 
   /// Creates an H1 view with some static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/Sections/H2.swift
+++ b/Sources/Slipstream/W3C/Elements/Sections/H2.swift
@@ -25,9 +25,9 @@ public struct H2<Content>: W3CElement where Content: View {
   }
 
   /// Creates an H2 view with some static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/Sections/H4.swift
+++ b/Sources/Slipstream/W3C/Elements/Sections/H4.swift
@@ -25,9 +25,9 @@ public struct H4<Content>: W3CElement where Content: View {
   }
 
   /// Creates an H4 view with some static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/Sections/H5.swift
+++ b/Sources/Slipstream/W3C/Elements/Sections/H5.swift
@@ -25,9 +25,9 @@ public struct H5<Content>: W3CElement where Content: View {
   }
 
   /// Creates an H5 view with some static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/Sections/H6.swift
+++ b/Sources/Slipstream/W3C/Elements/Sections/H6.swift
@@ -25,9 +25,9 @@ public struct H6<Content>: W3CElement where Content: View {
   }
 
   /// Creates an H6 view with some static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/Sections/Heading.swift
+++ b/Sources/Slipstream/W3C/Elements/Sections/Heading.swift
@@ -51,10 +51,10 @@ public struct Heading<Content>: View where Content: View {
   /// - Parameters:
   ///   - level: Must be a value between 1 and 6, inclusive.
   ///   - text: The string to render within this header.
-  public init(level: Int, _ text: String) where Content == Text {
+  public init(level: Int, _ text: String) where Content == DOMString {
     self.level = level
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 

--- a/Sources/Slipstream/W3C/Elements/TextLevelSemantics/Code.swift
+++ b/Sources/Slipstream/W3C/Elements/TextLevelSemantics/Code.swift
@@ -25,9 +25,9 @@ public struct Code<Content>: W3CElement where Content: View {
   }
 
   /// Creates a code view with static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/TextLevelSemantics/Link.swift
+++ b/Sources/Slipstream/W3C/Elements/TextLevelSemantics/Link.swift
@@ -35,11 +35,11 @@ public struct Link<Content>: View where Content: View {
   ///   - string: The text to display in this hyperlink.
   ///   - destination: The URL to open when this link is activated.
   ///   - openInNewTab: If true, clicking the link will cause a new tab to be opened.
-  public init(_ string: String, destination: URL?, openInNewTab: Bool = false) where Content == Text {
+  public init(_ string: String, destination: URL?, openInNewTab: Bool = false) where Content == DOMString {
     self.destination = destination
     self.openInNewTab = openInNewTab
     self.content = {
-      Text(string)
+      DOMString(string)
     }
   }
 

--- a/Sources/Slipstream/W3C/Elements/TextLevelSemantics/Small.swift
+++ b/Sources/Slipstream/W3C/Elements/TextLevelSemantics/Small.swift
@@ -30,9 +30,9 @@ public struct Small<Content>: W3CElement where Content: View {
   }
 
   /// Creates a view with static text that will be treated as small print.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/TextLevelSemantics/Span.swift
+++ b/Sources/Slipstream/W3C/Elements/TextLevelSemantics/Span.swift
@@ -27,9 +27,9 @@ public struct Span<Content>: W3CElement where Content: View {
   }
 
   /// Creates a span with static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/Slipstream/W3C/Elements/TextLevelSemantics/Strong.swift
+++ b/Sources/Slipstream/W3C/Elements/TextLevelSemantics/Strong.swift
@@ -26,9 +26,9 @@ public struct Strong<Content>: W3CElement where Content: View {
   }
 
   /// Creates a Strong view with static text.
-  public init(_ text: String) where Content == Text {
+  public init(_ text: String) where Content == DOMString {
     self.content = {
-      Text(text)
+      DOMString(text)
     }
   }
 }

--- a/Sources/SlipstreamCLI/main.swift
+++ b/Sources/SlipstreamCLI/main.swift
@@ -2,7 +2,7 @@ import Slipstream
 
 struct HelloWorld: View {
   var body: some View {
-    Text("Hello, world!")
+    DOMString("Hello, world!")
   }
 }
 

--- a/Tests/SlipstreamTests/AttributeModifierTests.swift
+++ b/Tests/SlipstreamTests/AttributeModifierTests.swift
@@ -12,7 +12,7 @@ private struct ModifiedView: View {
 
 private struct ModifiedText: View {
   var body: some View {
-    Text("Hello, world!")
+    DOMString("Hello, world!")
       .modifier(AttributeModifier(.lang, value: "en"))
   }
 }

--- a/Tests/SlipstreamTests/Attributes/ClassTests.swift
+++ b/Tests/SlipstreamTests/Attributes/ClassTests.swift
@@ -5,7 +5,7 @@ import Slipstream
 private struct ClassView: View {
   var body: some View {
     HTML {
-      Text("Bonjour!")
+      DOMString("Bonjour!")
         .classNames(["many", "classes"])
     }
     .className("root")

--- a/Tests/SlipstreamTests/Attributes/IDTests.swift
+++ b/Tests/SlipstreamTests/Attributes/IDTests.swift
@@ -5,7 +5,7 @@ import Slipstream
 private struct IDView: View {
   var body: some View {
     HTML {
-      Text("Bonjour!")
+      DOMString("Bonjour!")
     }
     .id("root")
   }

--- a/Tests/SlipstreamTests/Attributes/LanguageTests.swift
+++ b/Tests/SlipstreamTests/Attributes/LanguageTests.swift
@@ -5,7 +5,7 @@ import Slipstream
 private struct LanguageView: View {
   var body: some View {
     HTML {
-      Text("Bonjour!")
+      DOMString("Bonjour!")
     }
     .language("fr")
   }

--- a/Tests/SlipstreamTests/EnvironmentTests.swift
+++ b/Tests/SlipstreamTests/EnvironmentTests.swift
@@ -31,7 +31,7 @@ private struct ConsumerView: View {
   @Environment(\.path) var path
 
   var body: some View {
-    Text(path)
+    DOMString(path)
   }
 }
 

--- a/Tests/SlipstreamTests/HelloWorldTests.swift
+++ b/Tests/SlipstreamTests/HelloWorldTests.swift
@@ -10,6 +10,6 @@ private struct HelloWorld: View {
 
 struct HelloWorldTests {
   @Test func rendersExpectedResult() throws {
-    try #expect(renderHTML(HelloWorld()) == "Hello, world!")
+    try #expect(renderHTML(HelloWorld()) == "<p>Hello, world!</p>")
   }
 }

--- a/Tests/SlipstreamTests/Markdown/MarkdownTests.swift
+++ b/Tests/SlipstreamTests/Markdown/MarkdownTests.swift
@@ -13,7 +13,7 @@ This is some markdown content.
     ) { node, context in
       switch node {
       case let text as Markdown.Text:
-        Slipstream.Text(text.string)
+        Slipstream.DOMString(text.string)
       case let heading as Markdown.Heading:
         Slipstream.Heading(level: heading.level) {
           context.recurse()

--- a/Tests/SlipstreamTests/Sites/CatalogSiteTests.swift
+++ b/Tests/SlipstreamTests/Sites/CatalogSiteTests.swift
@@ -24,7 +24,7 @@ private struct CatalogSite: View {
           Link("About", destination: URL(string: "/about"))
 
           Link(URL(string: "/home")) {
-            Text("Home")
+            DOMString("Home")
           }
 
           VStack {
@@ -35,7 +35,7 @@ private struct CatalogSite: View {
                 .bold()
                 .textAlignment(.leading)
               H2 {
-                Text("Heading 2")
+                DOMString("Heading 2")
               }
               .fontSize(32)
               .textAlignment(.center)
@@ -98,8 +98,9 @@ struct CatalogSiteTests {
  </head>
  <body id="root">
   <div class="container border-b-4 border-b-black bg-[length:50px_100px] bg-[url('/logo.svg')] bg-no-repeat dark:text-red-800 lg:hover:px-12 duration-300 ease-in-out">
-   Hello
-   <br />world!
+   <p>Hello</p>
+   <br />
+   <p>world!</p>
    <a href="/about">About</a>
    <a href="/home">Home</a>
    <div class="flex flex-col items-start bg-black float-right gap-x-0.5 justify-center">

--- a/Tests/SlipstreamTests/StateTests.swift
+++ b/Tests/SlipstreamTests/StateTests.swift
@@ -5,7 +5,7 @@ import Slipstream
 private struct StateView: View {
   let string: String
   var body: some View {
-    Text(string)
+    DOMString(string)
   }
 }
 

--- a/Tests/SlipstreamTests/TailwindCSS/Layout/ContainerTests.swift
+++ b/Tests/SlipstreamTests/TailwindCSS/Layout/ContainerTests.swift
@@ -9,7 +9,7 @@ struct ContainerTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Container {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <div class="container">
  Hello, world!

--- a/Tests/SlipstreamTests/TailwindCSS/Layout/HStackTests.swift
+++ b/Tests/SlipstreamTests/TailwindCSS/Layout/HStackTests.swift
@@ -10,7 +10,7 @@ struct HStackTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(HStack {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <div class="flex flex-row items-center">
  Hello, world!

--- a/Tests/SlipstreamTests/TailwindCSS/Layout/ResponsiveStackTests.swift
+++ b/Tests/SlipstreamTests/TailwindCSS/Layout/ResponsiveStackTests.swift
@@ -10,7 +10,7 @@ struct ResponsiveStackTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(ResponsiveStack {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <div class="flex flex-col md:flex-row">
  Hello, world!

--- a/Tests/SlipstreamTests/TailwindCSS/Layout/VStackTests.swift
+++ b/Tests/SlipstreamTests/TailwindCSS/Layout/VStackTests.swift
@@ -20,7 +20,7 @@ struct VStackTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(VStack {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <div class="flex flex-col items-start">
  Hello, world!

--- a/Tests/SlipstreamTests/TailwindCSS/Layout/VStackTests.swift
+++ b/Tests/SlipstreamTests/TailwindCSS/Layout/VStackTests.swift
@@ -8,6 +8,16 @@ struct VStackTests {
     try #expect(renderHTML(VStack(reversed: true) {}) == #"<div class="flex flex-col-reverse items-start"></div>"#)
   }
 
+  @Test func alignment() throws {
+    try #expect(renderHTML(VStack(alignment: .stretch) {}) == #"<div class="flex flex-col items-stretch"></div>"#)
+    try #expect(renderHTML(VStack(alignment: .start) {}) == #"<div class="flex flex-col items-start"></div>"#)
+    try #expect(renderHTML(VStack(alignment: .center) {}) == #"<div class="flex flex-col items-center"></div>"#)
+    try #expect(renderHTML(VStack(alignment: .end) {}) == #"<div class="flex flex-col items-end"></div>"#)
+    try #expect(renderHTML(VStack(alignment: .baseline) {}) == #"<div class="flex flex-col items-baseline"></div>"#)
+    try #expect(renderHTML(VStack(alignment: .leading) {}) == #"<div class="flex flex-col items-start"></div>"#)
+    try #expect(renderHTML(VStack(alignment: .trailing) {}) == #"<div class="flex flex-col items-end"></div>"#)
+  }
+
   @Test func withText() throws {
     try #expect(renderHTML(VStack {
       Text("Hello, world!")

--- a/Tests/SlipstreamTests/TextTests.swift
+++ b/Tests/SlipstreamTests/TextTests.swift
@@ -4,10 +4,10 @@ import Slipstream
 
 struct TextTests {
   @Test func emptyText() throws {
-    try #expect(renderHTML(Text("")) == "")
+    try #expect(renderHTML(Text("")) == "<p></p>")
   }
 
   @Test func htmlCharactersEscaped() throws {
-    try #expect(renderHTML(Text("<p>Hello</p>")) == "&lt;p&gt;Hello&lt;/p&gt;")
+    try #expect(renderHTML(Text("<p>Hello</p>")) == "<p>&lt;p&gt;Hello&lt;/p&gt;</p>")
   }
 }

--- a/Tests/SlipstreamTests/ViewBuilderTests.swift
+++ b/Tests/SlipstreamTests/ViewBuilderTests.swift
@@ -4,14 +4,14 @@ import Slipstream
 
 private struct SingleBlockView: View {
   var body: some View {
-    Text("Hello, world!")
+    DOMString("Hello, world!")
   }
 }
 
 private struct TupleBlockView: View {
   var body: some View {
-    Text("Hello, ")
-    Text("world!")
+    DOMString("Hello, ")
+    DOMString("world!")
   }
 }
 
@@ -19,9 +19,9 @@ private struct IfElseBlockView: View {
   let bool: Bool
   var body: some View {
     if bool {
-      Text("true")
+      DOMString("true")
     } else {
-      Text("false")
+      DOMString("false")
     }
   }
 }
@@ -30,7 +30,7 @@ private struct IfBlockView: View {
   let bool: Bool
   var body: some View {
     if bool {
-      Text("true")
+      DOMString("true")
     }
   }
 }
@@ -38,7 +38,7 @@ private struct IfBlockView: View {
 private struct ArrayBlockView: View {
   var body: some View {
     for i in 1...3 {
-      Text("\(i)")
+      DOMString("\(i)")
     }
   }
 }

--- a/Tests/SlipstreamTests/W3C/BlockquoteTests.swift
+++ b/Tests/SlipstreamTests/W3C/BlockquoteTests.swift
@@ -9,7 +9,7 @@ struct BlockquoteTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Blockquote {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <blockquote>
  Hello, world!

--- a/Tests/SlipstreamTests/W3C/BodyTests.swift
+++ b/Tests/SlipstreamTests/W3C/BodyTests.swift
@@ -12,7 +12,7 @@ struct BodyTests {
       Head {
       }
       Body {
-        Text("Hello, world!")
+        DOMString("Hello, world!")
       }
     }) == """
 <html>

--- a/Tests/SlipstreamTests/W3C/CodeTests.swift
+++ b/Tests/SlipstreamTests/W3C/CodeTests.swift
@@ -9,7 +9,7 @@ struct CodeTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Code {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <code>Hello, world!</code>
 """)

--- a/Tests/SlipstreamTests/W3C/DivTests.swift
+++ b/Tests/SlipstreamTests/W3C/DivTests.swift
@@ -9,7 +9,7 @@ struct DivTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Div {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <div>
  Hello, world!

--- a/Tests/SlipstreamTests/W3C/FooterTests.swift
+++ b/Tests/SlipstreamTests/W3C/FooterTests.swift
@@ -9,7 +9,7 @@ struct FooterTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Footer {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <footer>
  Hello, world!

--- a/Tests/SlipstreamTests/W3C/HTMLTests.swift
+++ b/Tests/SlipstreamTests/W3C/HTMLTests.swift
@@ -9,7 +9,7 @@ struct HTMLTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(HTML {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <html>
  Hello, world!

--- a/Tests/SlipstreamTests/W3C/HeadTests.swift
+++ b/Tests/SlipstreamTests/W3C/HeadTests.swift
@@ -10,7 +10,7 @@ struct HeadTests {
   @Test func withText() throws {
     try #expect(renderHTML(HTML {
       Head {
-        Text("Hello, world!")
+        DOMString("Hello, world!")
       }
     }) == """
 <html>

--- a/Tests/SlipstreamTests/W3C/HeadingTests.swift
+++ b/Tests/SlipstreamTests/W3C/HeadingTests.swift
@@ -20,19 +20,19 @@ struct HeadingTests {
   }
 
   @Test func withText() throws {
-    try #expect(renderHTML(H1 { Text("Hello, world!") }) == "<h1>Hello, world!</h1>")
-    try #expect(renderHTML(H2 { Text("Hello, world!") }) == "<h2>Hello, world!</h2>")
-    try #expect(renderHTML(H3 { Text("Hello, world!") }) == "<h3>Hello, world!</h3>")
-    try #expect(renderHTML(H4 { Text("Hello, world!") }) == "<h4>Hello, world!</h4>")
-    try #expect(renderHTML(H5 { Text("Hello, world!") }) == "<h5>Hello, world!</h5>")
-    try #expect(renderHTML(H6 { Text("Hello, world!") }) == "<h6>Hello, world!</h6>")
+    try #expect(renderHTML(H1 { DOMString("Hello, world!") }) == "<h1>Hello, world!</h1>")
+    try #expect(renderHTML(H2 { DOMString("Hello, world!") }) == "<h2>Hello, world!</h2>")
+    try #expect(renderHTML(H3 { DOMString("Hello, world!") }) == "<h3>Hello, world!</h3>")
+    try #expect(renderHTML(H4 { DOMString("Hello, world!") }) == "<h4>Hello, world!</h4>")
+    try #expect(renderHTML(H5 { DOMString("Hello, world!") }) == "<h5>Hello, world!</h5>")
+    try #expect(renderHTML(H6 { DOMString("Hello, world!") }) == "<h6>Hello, world!</h6>")
 
-    try #expect(renderHTML(Heading(level: 1) { Text("Hello, world!") }) == "<h1>Hello, world!</h1>")
-    try #expect(renderHTML(Heading(level: 2) { Text("Hello, world!") }) == "<h2>Hello, world!</h2>")
-    try #expect(renderHTML(Heading(level: 3) { Text("Hello, world!") }) == "<h3>Hello, world!</h3>")
-    try #expect(renderHTML(Heading(level: 4) { Text("Hello, world!") }) == "<h4>Hello, world!</h4>")
-    try #expect(renderHTML(Heading(level: 5) { Text("Hello, world!") }) == "<h5>Hello, world!</h5>")
-    try #expect(renderHTML(Heading(level: 6) { Text("Hello, world!") }) == "<h6>Hello, world!</h6>")
+    try #expect(renderHTML(Heading(level: 1) { DOMString("Hello, world!") }) == "<h1>Hello, world!</h1>")
+    try #expect(renderHTML(Heading(level: 2) { DOMString("Hello, world!") }) == "<h2>Hello, world!</h2>")
+    try #expect(renderHTML(Heading(level: 3) { DOMString("Hello, world!") }) == "<h3>Hello, world!</h3>")
+    try #expect(renderHTML(Heading(level: 4) { DOMString("Hello, world!") }) == "<h4>Hello, world!</h4>")
+    try #expect(renderHTML(Heading(level: 5) { DOMString("Hello, world!") }) == "<h5>Hello, world!</h5>")
+    try #expect(renderHTML(Heading(level: 6) { DOMString("Hello, world!") }) == "<h6>Hello, world!</h6>")
   }
 
   @Test func attribute() throws {

--- a/Tests/SlipstreamTests/W3C/ListTests.swift
+++ b/Tests/SlipstreamTests/W3C/ListTests.swift
@@ -11,10 +11,10 @@ struct ListTests {
   @Test func withItems() throws {
     try #expect(renderHTML(List {
       ListItem {
-        Text("Item 1")
+        DOMString("Item 1")
       }
       ListItem {
-        Text("Item 2")
+        DOMString("Item 2")
       }
     }) == """
 <ul>
@@ -24,10 +24,10 @@ struct ListTests {
 """)
     try #expect(renderHTML(List(ordered: true) {
       ListItem {
-        Text("Item 1")
+        DOMString("Item 1")
       }
       ListItem {
-        Text("Item 2")
+        DOMString("Item 2")
       }
     }) == """
 <ol>

--- a/Tests/SlipstreamTests/W3C/NavigationTests.swift
+++ b/Tests/SlipstreamTests/W3C/NavigationTests.swift
@@ -9,7 +9,7 @@ struct NavigationTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Navigation {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <nav>
  Hello, world!

--- a/Tests/SlipstreamTests/W3C/ParagraphTests.swift
+++ b/Tests/SlipstreamTests/W3C/ParagraphTests.swift
@@ -9,7 +9,7 @@ struct ParagraphTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Paragraph {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <p>Hello, world!</p>
 """)

--- a/Tests/SlipstreamTests/W3C/PreformattedTests.swift
+++ b/Tests/SlipstreamTests/W3C/PreformattedTests.swift
@@ -9,7 +9,7 @@ struct PreformattedTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Preformatted {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <pre>Hello, world!</pre>
 """)

--- a/Tests/SlipstreamTests/W3C/SmallTests.swift
+++ b/Tests/SlipstreamTests/W3C/SmallTests.swift
@@ -9,7 +9,7 @@ struct SmallTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Small {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <small>Hello, world!</small>
 """)

--- a/Tests/SlipstreamTests/W3C/SpanTests.swift
+++ b/Tests/SlipstreamTests/W3C/SpanTests.swift
@@ -9,7 +9,7 @@ struct SpanTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Span {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <span>Hello, world!</span>
 """)

--- a/Tests/SlipstreamTests/W3C/StrongTests.swift
+++ b/Tests/SlipstreamTests/W3C/StrongTests.swift
@@ -9,7 +9,7 @@ struct StrongTests {
 
   @Test func withText() throws {
     try #expect(renderHTML(Strong {
-      Text("Hello, world!")
+      DOMString("Hello, world!")
     }) == """
 <strong>Hello, world!</strong>
 """)


### PR DESCRIPTION
This is being done to reduce friction for SwiftUI developers. It also provides greater distinction between raw DOM text vs structured views.