### PR TITLE
Adds arbitrary pixel values support for font sizes. (#60)

### DIFF
--- a/Sources/Slipstream/TailwindCSS/Typography/View+fontSize.swift
+++ b/Sources/Slipstream/TailwindCSS/Typography/View+fontSize.swift
@@ -48,7 +48,7 @@ extension View {
     return fontSize(closestTailwindFontSize(ptSize: ptSize), condition: condition)
   }
 
-  /// Set the font size to the closest equivalent Tailwind CSS font size.
+  /// Set the font size to the exact CSS pixel value.
   ///
   /// - Parameters:
   ///   - pxSize: A font size in `px` units.  

--- a/Sources/Slipstream/TailwindCSS/Typography/View+fontSize.swift
+++ b/Sources/Slipstream/TailwindCSS/Typography/View+fontSize.swift
@@ -48,6 +48,20 @@ extension View {
     return fontSize(closestTailwindFontSize(ptSize: ptSize), condition: condition)
   }
 
+  /// Set the font size to the closest equivalent Tailwind CSS font size.
+  ///
+  /// - Parameters:
+  ///   - pxSize: A font size in `px` units.  
+  ///   - condition: An optional Tailwind condition defining when to apply this modifier.
+  ///
+  /// - SeeAlso: Tailwind CSS' [`font-size`](https://tailwindcss.com/docs/font-size#arbitrary-values) documentation.
+  @available(iOS 17.0, macOS 14.0, *)
+  public func fontSize(px pxSize: Int, condition: Condition? = nil) -> some View {
+    return modifier(
+      TailwindClassModifier(add: "text-[\(pxSize)px]", condition: condition)
+    )
+  }
+
   private func closestTailwindFontSize(ptSize: Int) -> FontSize {
     // Mapping of Tailwind CSS font size classes to their point sizes.
     let fontSizeMapping: [(fontSize: FontSize, ptSize: Int)] = [

--- a/Tests/SlipstreamTests/TailwindCSS/Typography/FontSizeTests.swift
+++ b/Tests/SlipstreamTests/TailwindCSS/Typography/FontSizeTests.swift
@@ -41,7 +41,7 @@ struct FontSizeTests {
     try #expect(renderHTML(Div {}.fontSize(200)) == #"<div class="text-9xl"></div>"#)
   }
 
-  @Test func ExactFontSizes() throws {
+  @Test func exactFontSizes() throws {
     try #expect(renderHTML(Div {}.fontSize(px: 31)) == #"<div class="text-[31px]"></div>"#)
   }
 

--- a/Tests/SlipstreamTests/TailwindCSS/Typography/FontSizeTests.swift
+++ b/Tests/SlipstreamTests/TailwindCSS/Typography/FontSizeTests.swift
@@ -41,6 +41,10 @@ struct FontSizeTests {
     try #expect(renderHTML(Div {}.fontSize(200)) == #"<div class="text-9xl"></div>"#)
   }
 
+  @Test func ExactFontSizes() throws {
+    try #expect(renderHTML(Div {}.fontSize(px: 31)) == #"<div class="text-[31px]"></div>"#)
+  }
+
   @Test func condition() throws {
     try #expect(
       renderHTML(


### PR DESCRIPTION
Tried bringing support for arbitrary pixel values for `fontSize`.

Maybe there is a better way to bring a more generic support for arbitrary values, but keeping it simple for now since I'm super new to this codebase.

fixes #60

#first-contribution (maybe? 🙂)